### PR TITLE
Designate B.1.21, B.1.22 and C.1.1

### DIFF
--- a/auto-generated/lineages.json
+++ b/auto-generated/lineages.json
@@ -535,6 +535,57 @@
       "unaliased_name": "A.1.1.1.20"
     },
     {
+      "defining_snps": [
+        {
+          "nucleotide": "A",
+          "pos": 22415
+        },
+        {
+          "nucleotide": "T",
+          "pos": 132698
+        }
+      ],
+      "designation_date": "2023-04-15",
+      "name": "B.1.21",
+      "parent": "B.1",
+      "reference_sequences": [
+        {
+          "accession": "OP539939",
+          "isolate": "MPX/Human/USA/CA-LACPHL-MA00153/2022",
+          "source": "genbank"
+        }
+      ],
+      "unaliased_name": "A.1.1.1.21"
+    },
+    {
+      "defining_snps": [
+        {
+          "nucleotide": "T",
+          "pos": 34784
+        },
+        {
+          "nucleotide": "T",
+          "pos": 101418
+        }
+      ],
+      "designation_date": "2023-04-15",
+      "name": "B.1.22",
+      "parent": "B.1",
+      "reference_sequences": [
+        {
+          "accession": "OQ773522",
+          "isolate": "MPXV/Germany/2022/ON/RKI903",
+          "source": "genbank"
+        },
+        {
+          "accession": "OR095023",
+          "isolate": "MPXV/UZ_REGA_205/Belgium/2022",
+          "source": "genbank"
+        }
+      ],
+      "unaliased_name": "A.1.1.1.22"
+    },
+    {
       "alias": "C",
       "defining_snps": [
         {
@@ -704,6 +755,34 @@
     {
       "defining_snps": [
         {
+          "nucleotide": "T",
+          "pos": 21062
+        },
+        {
+          "nucleotide": "T",
+          "pos": 149963
+        }
+      ],
+      "designation_date": "2024-04-15",
+      "name": "C.1.1",
+      "parent": "C.1",
+      "reference_sequences": [
+        {
+          "accession": "OR643705",
+          "isolate": "MPV/Human/USA/CA-LACPHL-MA00563/2023",
+          "source": "genbank"
+        },
+        {
+          "accession": "OR804476",
+          "isolate": "MPV/PT0706/2023",
+          "source": "genbank"
+        }
+      ],
+      "unaliased_name": "A.1.1.1.3.1.1"
+    },
+    {
+      "defining_snps": [
+        {
           "nucleotide": "A",
           "pos": 105923
         },
@@ -730,5 +809,5 @@
     }
   ],
   "schemaVersion": "1.0.0",
-  "timestamp": "2023-07-31T09:17:14"
+  "timestamp": "2024-04-15T18:13:21"
 }

--- a/auto-generated/lineages.md
+++ b/auto-generated/lineages.md
@@ -132,6 +132,18 @@
  * defining SNPs: 53326A,164385T,187620T
  * reference sequence: [MPXV_USA_2022_TX0040](https://www.ncbi.nlm.nih.gov/nuccore/OQ320441)
 
+## B.1.21
+ * parent: [B.1](#B1)
+ * defining SNPs: 22415A,132698T
+ * reference sequence: [MPX/Human/USA/CA-LACPHL-MA00153/2022](https://www.ncbi.nlm.nih.gov/nuccore/OP539939)
+
+## B.1.22
+ * parent: [B.1](#B1)
+ * defining SNPs: 34784T,101418T
+ * reference sequences:
+   - [MPXV/Germany/2022/ON/RKI903](https://www.ncbi.nlm.nih.gov/nuccore/OQ773522)
+   - [MPXV/UZ_REGA_205/Belgium/2022](https://www.ncbi.nlm.nih.gov/nuccore/OR095023)
+
 ## B.1.3
  * parent: [B.1](#B1)
  * defining SNPs: 190660A
@@ -174,4 +186,11 @@
  * parent: [B.1.3](#B13)
  * defining SNPs: 105923A,64426T,55133A
  * reference sequence: [MPXV/human/Japan/Tokyo/2022/TKY220165](https://www.ncbi.nlm.nih.gov/nuccore/LC753968)
+
+## C.1.1
+ * parent: [C.1](#C1)
+ * defining SNPs: 21062T,149963T
+ * reference sequences:
+   - [MPV/Human/USA/CA-LACPHL-MA00563/2023](https://www.ncbi.nlm.nih.gov/nuccore/OR643705)
+   - [MPV/PT0706/2023](https://www.ncbi.nlm.nih.gov/nuccore/OR804476)
 

--- a/designation_records/B.1.21-B.1.22-C.1_2024-04-15.md
+++ b/designation_records/B.1.21-B.1.22-C.1_2024-04-15.md
@@ -1,0 +1,32 @@
+# Designation of two B.1 sublineages and one C.1 sublineage
+
+Transmission of descendants of the 2022 outbreak lineage B.1 is ongoing in 2023 and 2024. Most of the sequenced genomes fall within one of 4 lineages, 3 of which are newly designated here: B.1.21, B.1.22, C.1.1, while B.1.20 is a previously designated lineage. With these designations.
+
+All of the 3 lineages satisfy the criteria for lineage designation last updated in October 2023:
+
+- International spread
+- Having at least 2 mutation above the parent lineage (increased from 1)
+- Containing at least 15 sequences or plausibly represents undersampled diversity
+- Clear common phylogenetic structure (no uncertainty about possibly being designated as 2 lineages instead of 1)
+- Has at least one freely available high quality reference sequence
+
+#### B.1.21
+
+This is a mostly cross-US lineage with the most recent sequence collected in February 2024.
+
+It is defined by `G22415A` and `C132698T`.
+The yaml file can be found [here](../lineages/B.1.21.yml).
+
+#### B.1.22
+
+This is a mostly German lineage with the most recent sequence collected in March 2024.
+
+It is defined by `C34784T` and `C101418T`.
+The yaml file can be found [here](../lineages/B.1.22.yml).
+
+#### C.1.1 (alias of B.1.3.1.1)
+
+This is a global lineage with the most recent sequence collected in March 2024. It was sequenced particularly frequently in Portugal, but also in Germany and the US - which are the major sequencing countries that submit to the INSDC. GISAID-only sequences indicate this lineage was common in China.
+
+It is defined by `C21062T` and `C149963T`.
+The `yaml` file can be found [here](../lineages/C.1.1.yml).

--- a/lineages/B.1.21.yml
+++ b/lineages/B.1.21.yml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=../schemas/single_lineage/lineage_schema_1-0-0.yml
+name: B.1.21
+unaliased_name: A.1.1.1.21
+parent: B.1
+designation_date: "2023-04-15"
+defining_snps:
+  - pos: 22415
+    nucleotide: A
+  - pos: 132698
+    nucleotide: T
+reference_sequences:
+  - source: genbank
+    accession: OP539939
+    isolate: MPX/Human/USA/CA-LACPHL-MA00153/2022

--- a/lineages/B.1.22.yml
+++ b/lineages/B.1.22.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../schemas/single_lineage/lineage_schema_1-0-0.yml
+name: B.1.22
+unaliased_name: A.1.1.1.22
+parent: B.1
+designation_date: "2023-04-15"
+defining_snps:
+  - pos: 34784
+    nucleotide: T
+  - pos: 101418
+    nucleotide: T
+reference_sequences:
+  - source: genbank
+    accession: OQ773522
+    isolate: MPXV/Germany/2022/ON/RKI903
+  - source: genbank
+    accession: OR095023
+    isolate: MPXV/UZ_REGA_205/Belgium/2022

--- a/lineages/C.1.1.yml
+++ b/lineages/C.1.1.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../schemas/single_lineage/lineage_schema_1-0-0.yml
+name: C.1.1
+unaliased_name: A.1.1.1.3.1.1
+parent: C.1
+designation_date: "2024-04-15"
+defining_snps:
+  - pos: 21062
+    nucleotide: T
+  - pos: 149963
+    nucleotide: T
+reference_sequences:
+  - source: genbank
+    accession: OR643705
+    isolate: MPV/Human/USA/CA-LACPHL-MA00563/2023
+  - source: genbank
+    accession: OR804476
+    isolate: MPV/PT0706/2023


### PR DESCRIPTION
Resolves #34, #35, #36 

Designation of the major lineages still being sequenced since mid-2023